### PR TITLE
Add shed rate, add toggle for time visual effects, remove toggle for vector effects

### DIFF
--- a/Fractal-Universe-Simulation-PoC/client/src/components/EnergyParticle.tsx
+++ b/Fractal-Universe-Simulation-PoC/client/src/components/EnergyParticle.tsx
@@ -11,10 +11,10 @@ interface EnergyParticleProps {
 export default function EnergyParticle({ energy }: EnergyParticleProps) {
   const { energySize, showVelocityVectors } = useSimulation();
   const energyRef = useRef<THREE.Mesh>(null);
-  
+
   // Create a ref for the velocity arrow
   const arrowRef = useRef<THREE.ArrowHelper>(null);
-  
+
   // Update the energy visualization every frame
   useFrame(() => {
     if (energyRef.current) {
@@ -22,26 +22,26 @@ export default function EnergyParticle({ energy }: EnergyParticleProps) {
       energyRef.current.position.y = energy.position.y;
 
       const sz = Math.pow(energy.size, 0.8);
-      
+
       // Set a fixed scale for the energy without pulsing effect
       energyRef.current.scale.set(
-        sz, 
-        sz, 
+        sz,
+        sz,
         1
       );
     }
-    
+
     // Update velocity arrow
     if (arrowRef.current && showVelocityVectors) {
       // Direction vector from velocity
       const dir = new THREE.Vector3(energy.velocity.x, energy.velocity.y, 0);
       dir.normalize();
-      
+
       // Update arrow position and direction
       arrowRef.current.position.set(energy.position.x, energy.position.y, 0.1);
       arrowRef.current.setDirection(dir);
       arrowRef.current.setLength(energySize * 1.5); // Scale arrow with energy size
-      
+
       // Make arrow visible
       arrowRef.current.visible = true;
     } else if (arrowRef.current) {
@@ -52,30 +52,30 @@ export default function EnergyParticle({ energy }: EnergyParticleProps) {
 
   // Calculate color based on energy velocity
   const speed = Math.sqrt(
-    energy.velocity.x * energy.velocity.x + 
+    energy.velocity.x * energy.velocity.x +
     energy.velocity.y * energy.velocity.y
   );
-  
+
   // Create color gradient from blue to red based on speed
-  const hue = Math.max(0, Math.min(240 - speed * 60, 240));
+  const hue = Math.max(0, Math.min(240 - speed * 20, 240));
   const color = new THREE.Color(`hsl(${hue}, 100%, 50%)`);
-  
+
   return (
     <group>
       <mesh ref={energyRef} position={[energy.position.x, energy.position.y, 0.1]}>
         <circleGeometry args={[1, 64]} />
         <meshBasicMaterial color={color} transparent opacity={0.9} />
       </mesh>
-      
+
       {/* Velocity vector visualization */}
-      <primitive 
+      <primitive
         ref={arrowRef}
         object={new THREE.ArrowHelper(
           new THREE.Vector3(energy.velocity.x, energy.velocity.y, 0).normalize(),
           new THREE.Vector3(energy.position.x, energy.position.y, 0.1),
           energySize * 1.5, // Length
           0xffff00 // Color
-        )} 
+        )}
         visible={showVelocityVectors}
       />
     </group>

--- a/Fractal-Universe-Simulation-PoC/client/src/components/EnergyParticle.tsx
+++ b/Fractal-Universe-Simulation-PoC/client/src/components/EnergyParticle.tsx
@@ -9,7 +9,7 @@ interface EnergyParticleProps {
 }
 
 export default function EnergyParticle({ energy }: EnergyParticleProps) {
-  const { energySize, showVelocityVectors } = useSimulation();
+  const { energySize, showVelocityVectors, showTimeEffects } = useSimulation();
   const energyRef = useRef<THREE.Mesh>(null);
 
   // Create a ref for the velocity arrow
@@ -58,7 +58,12 @@ export default function EnergyParticle({ energy }: EnergyParticleProps) {
 
   // Create color gradient from blue to red based on speed
   const hue = Math.max(0, Math.min(240 - speed * 20, 240));
-  const color = new THREE.Color(`hsl(${hue}, 100%, 50%)`);
+  let color;
+  if (showTimeEffects) {
+    color = new THREE.Color(`hsl(${hue}, 100%, 50%)`);
+  } else {
+    color = new THREE.Color(`hsl(0%, 100%, 50%)`);
+  }
 
   return (
     <group>

--- a/Fractal-Universe-Simulation-PoC/client/src/components/SimulationControls.tsx
+++ b/Fractal-Universe-Simulation-PoC/client/src/components/SimulationControls.tsx
@@ -26,6 +26,12 @@ export default function SimulationControls() {
     spacetimePressureMultiplier,
     energySize,
     setEnergySize,
+    energyBaseShedRate,
+    setEnergyBaseShedRate,
+    energyDisplacementShedRate,
+    setEnergyDisplacementShedRate,
+    energyShedFactor,
+    setEnergyShedFactor,
     showGrid,
     setShowGrid,
     showVelocityVectors,
@@ -93,6 +99,33 @@ export default function SimulationControls() {
               max={5}
               step={0.1}
               onChange={(value) => setEnergySize(value[0])}
+            />
+
+            <SliderLabel
+              label="Energy Base Shed Rate"
+              value={energyBaseShedRate}
+              min={0}
+              max={0.5}
+              step={0.01}
+              onChange={(value) => setEnergyBaseShedRate(value[0])}
+            />
+
+            <SliderLabel
+              label="Energy Displacement Shed Rate"
+              value={energyDisplacementShedRate}
+              min={0}
+              max={1.0}
+              step={0.02}
+              onChange={(value) => setEnergyDisplacementShedRate(value[0])}
+            />
+
+            <SliderLabel
+              label="Energy Shed Factor"
+              value={energyShedFactor}
+              min={0.1}
+              max={2.0}
+              step={0.1}
+              onChange={(value) => setEnergyShedFactor(value[0])}
             />
 
             <SliderLabel

--- a/Fractal-Universe-Simulation-PoC/client/src/components/SimulationControls.tsx
+++ b/Fractal-Universe-Simulation-PoC/client/src/components/SimulationControls.tsx
@@ -42,6 +42,8 @@ export default function SimulationControls() {
     setParentFieldSkew,
     timeFactor,
     setTimeFactor,
+    showTimeEffects,
+    setShowTimeEffects,
   } = useSimulation();
 
   return (
@@ -137,7 +139,7 @@ export default function SimulationControls() {
               onChange={(value) => setEnergySteerFactor(value[0])}
             />
 
-            <div className="flex items-center space-x-2 pt-2">
+            {/* <div className="flex items-center space-x-2 pt-2">
               <Switch
                 id="show-vectors"
                 checked={showVelocityVectors}
@@ -146,7 +148,7 @@ export default function SimulationControls() {
               <Label htmlFor="show-vectors" className="text-white">
                 Show Velocity Vectors
               </Label>
-            </div>
+            </div> */}
           </div>
 
           <div className="space-y-2 pt-2">
@@ -210,6 +212,15 @@ export default function SimulationControls() {
               max={8}
               step={0.5}
               onChange={(value) => setTimeFactor(value[0])}
+            />
+
+            <SliderLabel
+              label="Show Time Effects"
+              value={showTimeEffects}
+              min={0}
+              max={1}
+              step={1}
+              onChange={(value) => setShowTimeEffects(value[0])}
             />
           </div>
         </div>

--- a/Fractal-Universe-Simulation-PoC/client/src/lib/physics.ts
+++ b/Fractal-Universe-Simulation-PoC/client/src/lib/physics.ts
@@ -59,6 +59,10 @@ export function calculateDisplacement(
   };
 }
 
+interface Vector2WithScale {
+  vector: Vector2;
+  timeScale: number;
+}
 
 export function calculateEnergyRedirection(
   velocity: Vector2,
@@ -69,12 +73,12 @@ export function calculateEnergyRedirection(
   energySize: number = 1,
   parentFieldSkew: number = 0.0,
   timeFactor: number = 1,
-): Vector2 {
+): Vector2WithScale {
   const dispMag = Math.hypot(displacement.x, displacement.y);
-  if (dispMag < 0.01) return { ...velocity };
+  if (dispMag < 0.01) return { vector: velocity, timeScale: 1 };
 
   const velMag = Math.hypot(velocity.x, velocity.y);
-  if (velMag < 0.01) return { ...velocity };
+  if (velMag < 0.01) return { vector: velocity, timeScale: 1 };
 
   const normVel = {
     x: velocity.x / velMag,
@@ -125,6 +129,7 @@ export function calculateEnergyRedirection(
 
   const redirMag = Math.hypot(redirVec.x, redirVec.y);
   let scale = velMag / redirMag;
+  let timeScale = 1;
 
   // Calculate time scaling based on displacement difference
   if (timeFactor != 0 && dispMag > 0.01) {
@@ -149,7 +154,7 @@ export function calculateEnergyRedirection(
       const magnitudeRatio = dispDiffMag / velMag;
 
       // Combine alignment and magnitude for time scaling
-      const timeScale = alignment * magnitudeRatio;
+      timeScale = alignment * magnitudeRatio;
 
       // Apply time factor with 0 as the neutral point
       scale *= (1 + timeScale * timeFactor);
@@ -157,7 +162,8 @@ export function calculateEnergyRedirection(
   }
 
   return {
-    x: redirVec.x * scale,
-    y: redirVec.y * scale,
+    vector: {x: redirVec.x * scale,
+    y: redirVec.y * scale},
+    timeScale: Math.min(1, Math.abs(timeScale * timeFactor)),
   };
 }

--- a/Fractal-Universe-Simulation-PoC/client/src/lib/stores/useSimulation.ts
+++ b/Fractal-Universe-Simulation-PoC/client/src/lib/stores/useSimulation.ts
@@ -19,6 +19,7 @@ interface SimulationState {
   spacetimePressureMultiplier: number;
   showGrid: boolean;
   showVelocityVectors: boolean;
+  showTimeEffects: number;
   isPaused: boolean;
 
   forwardDisplacementFactor: number;
@@ -54,6 +55,7 @@ interface SimulationState {
   setShowGrid: (show: boolean) => void;
   setShowVelocityVectors: (show: boolean) => void;
   setForwardDisplacementFactor: (factor: number) => void;
+  setShowTimeEffects: (show: number) => void;
   togglePause: () => void;
 
   addEnergy: (energy: Partial<Energy>) => void;
@@ -106,6 +108,7 @@ export const useSimulation = create<SimulationState>((set, get) => {
     parentFieldSkew: 0,
     directionMode: 'cycle' as const,
     timeFactor: 1.0,
+    showTimeEffects: 1,
   };
   // Initialize the grid cells
   const initializeGrid = (size: number): GridCell[] => {
@@ -156,6 +159,7 @@ export const useSimulation = create<SimulationState>((set, get) => {
     setParentFieldSkew: (skew) => set({ parentFieldSkew: skew }),
     setDirectionMode: (mode) => set({ directionMode: mode }),
     setTimeFactor: (factor) => set({ timeFactor: factor }),
+    setShowTimeEffects: (show) => set({ showTimeEffects: show }),
 
     // Energy management
     addEnergy: (energy) => {


### PR DESCRIPTION
First iteration on shed rate. This is to emulate the "bleed" of energy as it propagates around and sheds. In general, I find this not useful, but it does help complete the theory which says this should be happening.

Despite the name, energy can also grow as shed is allowed to go negative. The behavior here is likely incorrect, but was put in place to help create "stable" energy sizes. Going negative is itself not wrong - its probable at a quantum level that energy sheds, and then reaccumulates frequently, but it does sometimes create quirky effects when turned up and around black holes where stuff just blows up in size.

I found the time effect flickering nauseating and added an option to turn it off. I guess this is where that warning comes from in games.